### PR TITLE
Limit DXCC name to 30 chars

### DIFF
--- a/application/controllers/Cfdexport.php
+++ b/application/controllers/Cfdexport.php
@@ -52,7 +52,7 @@ Entity                \          MHz:   ALL   1.8   3.5     7    10    14    18 
 			if ($row->cnfmd >=1) { $dxcc_list[$row->prefix][$nominal][$row->mode]=$row->mode; }
 		}
 		foreach ($dxcc_list as $pref => $vals) {	// Loop through new array
-			$output .= str_pad($pref,6," ")." ".str_pad($dxcc_list[$pref]['name'],30,".")."  ";
+			$output .= str_pad($pref,6," ")." ".str_pad(substr($dxcc_list[$pref]['name'],0,30),30,".")."  ";
 			$allm=0;
 			$allc=0;
 			$allf=0;


### PR DESCRIPTION
Avoids:

![Screenshot from 2024-02-08 14-40-08](https://github.com/int2001/wavelog/assets/7112907/c92f12f0-0edb-46a5-a1d4-3bdffe67b228)
