### PR TITLE
Some Performance Enhancements

### DIFF
--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -377,10 +377,12 @@ if ($('#frequency').val() == "") {
 
 /* on mode change */
 $('#mode').change(function () {
+		if ($('#radio').val() == '0') {
 	$.get('qso/band_to_freq/' + $('#band').val() + '/' + $('.mode').val(), function (result) {
 		$('#frequency').val(result);
 		$('#frequency_rx').val("");
 	});
+	}
 	setRst($("#mode").val());
 	checkIfWorkedBefore();
 });
@@ -388,10 +390,12 @@ $('#mode').change(function () {
 /* Calculate Frequency */
 /* on band change */
 $('#band').change(function () {
+		if ($('#radio').val() == '0') {
 	$.get('qso/band_to_freq/' + $(this).val() + '/' + $('.mode').val(), function (result) {
 		$('#frequency').val(result);
 		$('#frequency_rx').val("");
 	});
+	}
 	checkIfWorkedBefore();
 });
 

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -53,13 +53,13 @@ async function reset_contest_session() {
 			"columnDefs": [
 				{
 					"render": function ( data, type, row ) {
-						return pad(row[8],3);
+						return row[8] !== null && row[8] !== '' ? pad(row[8], 3) : '';
 					},
 					"targets" : 8
 				},
 				{
 					"render": function ( data, type, row ) {
-						return pad(row[9],3);
+						return row[9] !== null && row[9] !== '' ? pad(row[9], 3) : '';
 					},
 					"targets" : 9
 				}
@@ -624,13 +624,13 @@ async function refresh_qso_table(data) {
 						"columnDefs": [
 							{
 								"render": function ( data, type, row ) {
-									return pad(row[8],3);
+									return row[8] !== null && row[8] !== '' ? pad(row[8], 3) : '';
 								},
 								"targets" : 8
 							},
 							{
 								"render": function ( data, type, row ) {
-									return pad(row[9],3);
+									return row[9] !== null && row[9] !== '' ? pad(row[9], 3) : '';
 								},
 								"targets" : 9
 							}

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -637,34 +637,33 @@ async function refresh_qso_table(data) {
 				table.clear();
 
 				var mode = '';
-				var data;
-				$.each(html, function () {
-					if (this.col_submode == null || this.col_submode == '') {
-						mode = this.col_mode;
-					} else {
-						mode = this.col_submode;
-					}
+				var data = [];
+                $.each(html, function () {
+                    if (this.col_submode == null || this.col_submode == '') {
+                        mode = this.col_mode;
+                    } else {
+                        mode = this.col_submode;
+                    }
 
-					data = [[
-						this.col_time_on,
-						this.col_call,
-						this.col_band,
-						mode,
-						this.col_rst_sent,
-						this.col_rst_rcvd,
-						this.col_stx_string,
-						this.col_srx_string,
-						this.col_stx,
-						this.col_srx,
-						this.col_gridsquare,
-						this.col_vucc_grids
-					]];
+                    data.push([
+                        this.col_time_on,
+                        this.col_call,
+                        this.col_band,
+                        mode,
+                        this.col_rst_sent,
+                        this.col_rst_rcvd,
+                        this.col_stx_string,
+                        this.col_srx_string,
+                        this.col_stx,
+                        this.col_srx,
+                        this.col_gridsquare,
+                        this.col_vucc_grids
+                    ]);
+                });
 
-					if (data.length > 0) {
-						table.rows.add(data).draw();
-					}
-
-				});
+                if (data.length > 0) {
+                    table.rows.add(data).draw();
+                }
 
 			}
 		});

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -477,6 +477,7 @@ function logQso() {
 	if ($("#callsign").val().length > 0) {
 
 		$('.callsign-suggestions').text("");
+		$('#callsign_info').text("");
 
 		var table = $('.qsotable').DataTable();
 		var exchangetype = $("#exchangetype").val();


### PR DESCRIPTION
this solves mainly 3 issues

1. huge performance issue when there are a bigger amount of QSO's in json data. I tested with > 100 QSO's in the table. after logging a new Callsign it takes several seconds (up to 6 seconds on my Macbook Pro 2016 and Chrome) before I can enter the next callsign. filling the table with a bulk instead of line by line this performance issue should be solved. I didn't test more then 120 qso's but the "waiting time" before the datatable is ready is now less then a second and not an issue anymore. (see around line 645)

2. smaller issue but annoying. If I choose a radio the frequency gots overwritten with CAT data. But then because the frequency changed it gots overwritte again by the default mode/band frequency. Now we check first if radio is 0

3. Also a small issue but we don't need to show '000' in the datatable if there is no serialnumber exchanged (for example a string exchange instead). The cell is empty now if the data is empty.


There is "one more thing", but I will create a new PR for that, since this doesn't have to do something with performance tuning.