### PR TITLE
Hide empty Information card completey

### DIFF
--- a/application/views/lotw_views/index.php
+++ b/application/views/lotw_views/index.php
@@ -139,13 +139,13 @@
 	<br>
 
 	<!-- Card Starts -->
+	<?php
+	if (!($this->config->item('disable_manual_lotw'))) { ?>
 	<div class="card">
 		<div class="card-header">
 			<?php echo lang('lotw_title_information'); ?>
 		</div>
 
-		<?php
-		if (!($this->config->item('disable_manual_lotw'))) { ?>
 		<div class="card-body">
 			<button class="btn btn-outline-success" hx-get="<?php echo site_url('lotw/lotw_upload'); ?>"  hx-target="#lotw_manual_results">
 				<?php echo lang('lotw_btn_manual_sync'); ?>
@@ -153,7 +153,7 @@
 
 			<div id="lotw_manual_results"></div>
 		</div>
-		<?php } ?>
 	</div>
+	<?php } ?>
 
 </div>


### PR DESCRIPTION
Maybe more user friendly to hide the Information card completely instead of having it just empty:

![Screenshot from 2024-05-16 13-51-01](https://github.com/int2001/wavelog/assets/7112907/ee894105-072c-4879-bd24-512e83092cd4)
