### PR TITLE
Use slash for separating version and correct indent

### DIFF
--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -39,7 +39,7 @@ class Qrz extends CI_Controller {
 		curl_setopt( $ch, CURLOPT_HEADER, 0);
 		curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT, 20);
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt( $ch, CURLOPT_USERAGENT, 'Wavelog '.$this->optionslib->get_option('version'));
+		curl_setopt( $ch, CURLOPT_USERAGENT, 'Wavelog/'.$this->optionslib->get_option('version'));
 		
 		$content = curl_exec($ch);
 		curl_close($ch);
@@ -359,7 +359,7 @@ class Qrz extends CI_Controller {
 		curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, 1);
 		curl_setopt( $ch, CURLOPT_HEADER, 0);
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt( $ch, CURLOPT_USERAGENT, 'Wavelog '.$this->optionslib->get_option('version'));
+		curl_setopt( $ch, CURLOPT_USERAGENT, 'Wavelog/'.$this->optionslib->get_option('version'));
 
 		$content = htmlspecialchars_decode(curl_exec($ch));
 		file_put_contents($file, $content);

--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -19,8 +19,8 @@ class Qrz {
 		curl_setopt($ch, CURLOPT_HEADER, false);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
-	        curl_setopt($ch, CURLOPT_TIMEOUT, 10);
-		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog '.$ci->optionslib->get_option('version'));
+		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 		$xml = curl_exec($ch);
 		curl_close($ch);
 		
@@ -45,8 +45,8 @@ class Qrz {
 		curl_setopt($ch, CURLOPT_HEADER, false);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
-        	curl_setopt($ch, CURLOPT_TIMEOUT, 10);
-		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog '.$ci->optionslib->get_option('version'));
+		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 		$xml = curl_exec($ch);
 		curl_close($ch);
 		
@@ -75,7 +75,7 @@ class Qrz {
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 			curl_setopt($ch, CURLOPT_TIMEOUT, 10);
-			curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog '.$ci->optionslib->get_option('version'));
+			curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 			$xml = curl_exec($ch);
 			$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 			curl_close($ch);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -994,7 +994,7 @@ class Logbook_model extends CI_Model {
 		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
 		curl_setopt($ch, CURLOPT_HEADER, 0);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog '.$this->optionslib->get_option('version'));
+		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$this->optionslib->get_option('version'));
 		$content = curl_exec($ch);
 		if ($content) {
 			if (stristr($content, 'RESULT=OK') || stristr($content, 'RESULT=REPLACE')) {


### PR DESCRIPTION
Seems like using slash to separate user agent from version is common practice. Also fixed some indents :)